### PR TITLE
Fix broken path and syntax errors in config files

### DIFF
--- a/nginx/conf.d/default.conf.template
+++ b/nginx/conf.d/default.conf.template
@@ -37,4 +37,3 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 }
-}

--- a/scripts/ssl-monitor.sh
+++ b/scripts/ssl-monitor.sh
@@ -5,8 +5,7 @@ CERT_PATH="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
 DAYS_THRESHOLD=30
 INFRASTRUCTURE_DIR="$HOME/fourseven_oneseven/fourseven_oneseven_infrastructure"
 NGINX_DIR="$INFRASTRUCTURE_DIR/nginx"
-REBUILD_SCRIPT="/home/pi/fourseven_oneseven/fourseven_oneseven_infrastructure
-/scripts/rebuild-prod.sh"
+REBUILD_SCRIPT="/home/pi/fourseven_oneseven/fourseven_oneseven_infrastructure/scripts/rebuild-prod.sh"
 
 if [ -f "$CERT_PATH" ]; then
     expiry_date=$(openssl x509 -enddate -noout -in "$CERT_PATH" | cut -d= -f2)

--- a/scripts/ssl-monitor.sh
+++ b/scripts/ssl-monitor.sh
@@ -5,7 +5,7 @@ CERT_PATH="/etc/letsencrypt/live/$DOMAIN/fullchain.pem"
 DAYS_THRESHOLD=30
 INFRASTRUCTURE_DIR="$HOME/fourseven_oneseven/fourseven_oneseven_infrastructure"
 NGINX_DIR="$INFRASTRUCTURE_DIR/nginx"
-REBUILD_SCRIPT="/home/pi/fourseven_oneseven/fourseven_oneseven_infrastructure/scripts/rebuild-prod.sh"
+REBUILD_SCRIPT="$INFRASTRUCTURE_DIR/scripts/rebuild-prod.sh"
 
 if [ -f "$CERT_PATH" ]; then
     expiry_date=$(openssl x509 -enddate -noout -in "$CERT_PATH" | cut -d= -f2)


### PR DESCRIPTION
- Fix ssl-monitor.sh: REBUILD_SCRIPT path was incorrectly split across two lines
- Fix default.conf.template: Remove extra closing brace causing nginx syntax error